### PR TITLE
[WIP] Implement sending welcome packets to clickers

### DIFF
--- a/emulator/iSkipper/examples/capture/capture.ino
+++ b/emulator/iSkipper/examples/capture/capture.ino
@@ -30,7 +30,12 @@ void setup()
 void loop()
 {
   char tmp[50];
-  iClickerPacket r;  
+  iClickerPacket r;
+
+  Serial.println("Sending welcome message");
+  clicker.sendWelcomePacket("_0+2-2=x_?", QuestionModes::MULTIPLE_NUMERIC, 5);
+  clicker.setChannel(iClickerChannels::AA);
+  clicker.startPromiscuous(CHANNEL_SEND, recvPacketHandler);
 
   //see if there is a pending packet, check if its an answer packet
   while (recvBuf.pull(&r) && r.type == PACKET_ANSWER) {

--- a/emulator/iSkipper/iClickerEmulator.h
+++ b/emulator/iSkipper/iClickerEmulator.h
@@ -23,6 +23,44 @@ enum iClickerAnswer : uint8_t
     NUM_ANSWER_CHOICES,
 };
 
+struct QuestionMode 
+{
+    // magic bytes used in the welcome packet for this
+    // question mode
+    uint8_t welcome_bytes[2];
+};
+
+namespace QuestionModes {
+    const QuestionMode MULTIPLE_CHOICE = 
+    {
+        {0x92, 0x62}
+    };
+
+    const QuestionMode NUMERIC =
+    {
+        {0x93, 0x63}
+    };
+
+    const QuestionMode ALPHANUMERIC =
+    {
+        {0x9B, 0x6B}
+    };
+
+    const QuestionMode MULTIPLE_NUMERIC =
+    {
+        {0x94, 0x64}
+    };
+
+    const QuestionMode MULTIPLE_ALPHANUMERIC =
+    {
+        {0x9C, 0x6C}
+    };
+};
+
+#define WELCOME_RECV_SYNC_ADDR_LEN 6
+const uint8_t WELCOME_RECV_SYNC_ADDR[WELCOME_RECV_SYNC_ADDR_LEN] = 
+    {0x55, 0x55, 0x55, 0x36, 0x36, 0x36};
+
 
 // Encoded answer choice is sent as follows:
 /*
@@ -111,6 +149,8 @@ public:
     bool begin(iClickerChannel chan);
     bool submitAnswer(uint8_t id[ICLICKER_ID_LEN], iClickerAnswer ans,
             bool withAck=false, uint32_t timeout=DEFAULT_ACK_TIMEOUT, bool waitClear = true);
+    void sendWelcomePacket(char* msg, QuestionMode mode=QuestionModes::MULTIPLE_CHOICE, 
+            uint16_t num_questions=0);
     void acknowledgeAnswer(iClickerAnswerPacket* packet, bool accept=true);
 
     void startPromiscuous(iClickerChannelType chanType, void (*cb)(iClickerPacket *));

--- a/emulator/iSkipper/iClickerRadio.cpp
+++ b/emulator/iSkipper/iClickerRadio.cpp
@@ -61,7 +61,7 @@ bool iClickerRadio::initialize(uint8_t freqBand)
         /* 0x37 */ { REG_PACKETCONFIG1, RF_PACKET1_FORMAT_FIXED | RF_PACKET1_DCFREE_OFF | RF_PACKET1_CRC_OFF | RF_PACKET1_CRCAUTOCLEAR_ON | RF_PACKET1_ADRSFILTERING_OFF },
         /* 0x38 */ { REG_PAYLOADLENGTH, PAYLOAD_LENGTH_SEND }, // in variable length mode: the max frame size, not used in TX
         ///* 0x39 */ { REG_NODEADRS, nodeID }, // turned off because we're not using address filtering
-        /* 0x3C */ { REG_FIFOTHRESH, RF_FIFOTHRESH_TXSTART_FIFOTHRESH | RF_FIFOTHRESH_TXSTART_FIFOTHRESH_IC  }, // TX on FIFO not empty
+        /* 0x3C */ { REG_FIFOTHRESH, RF_FIFOTHRESH_TXSTART_FIFONOTEMPTY | RF_FIFOTHRESH_VALUE  }, // TX on FIFO not empty
         /* 0x3D */ { REG_PACKETCONFIG2, RF_PACKET2_RXRESTARTDELAY_1BIT | RF_PACKET2_AUTORXRESTART_OFF | RF_PACKET2_AES_OFF }, // RXRESTARTDELAY must match transmitter PA ramp-down time (bitrate dependent)
         //for BR-19200: /* 0x3D */ { REG_PACKETCONFIG2, RF_PACKET2_RXRESTARTDELAY_NONE | RF_PACKET2_AUTORXRESTART_ON | RF_PACKET2_AES_OFF }, // RXRESTARTDELAY must match transmitter PA ramp-down time (bitrate dependent)
         /* 0x6F */ { REG_TESTDAGC, RF_DAGC_IMPROVED_LOWBETA0 }, // run DAGC continuously in RX mode for Fading Margin Improvement, recommended default for AfcLowBetaOn=0
@@ -126,8 +126,20 @@ void iClickerRadio::setChannelType(iClickerChannelType_t chanType)
     // dont change it if allready correct
     if (_chanType != chanType) {
         _chanType = chanType;
-        setFrequency(_chanType == CHANNEL_SEND ? _chan.send : _chan.recv);
-        setPayloadLength(_chanType == CHANNEL_SEND ? PAYLOAD_LENGTH_SEND : PAYLOAD_LENGTH_RECV, false);
+        switch (chanType) {
+            case CHANNEL_SEND:
+                setFrequency(_chan.send);
+                setPayloadLength(PAYLOAD_LENGTH_SEND, false);
+                break;
+            case CHANNEL_RECV:
+                setFrequency(_chan.recv);
+                setPayloadLength(PAYLOAD_LENGTH_RECV, false);
+                break;
+            case CHANNEL_RECV_WELCOME:
+                setFrequency(_chan.recv);
+                setPayloadLength(WELCOME_PACKET_SIZE, false);
+                break;
+        }
     }
 }
 

--- a/emulator/iSkipper/iClickerRadio.h
+++ b/emulator/iSkipper/iClickerRadio.h
@@ -5,9 +5,6 @@
 #include "iClickerRadioIncludes.h"
 #include "RFM69.h"
 
-// threshold for triggerins fifo transmit interrupt
-#define RF_FIFOTHRESH_TXSTART_FIFOTHRESH_IC 0x04
-
 
 //RegSyncValue1-8 for sending is:
 // 0x85, 0x85, 0x85, 0, 0...

--- a/emulator/iSkipper/iClickerRadioIncludes.h
+++ b/emulator/iSkipper/iClickerRadioIncludes.h
@@ -19,11 +19,13 @@
 //packet length
 #define PAYLOAD_LENGTH_SEND               0x05
 #define PAYLOAD_LENGTH_RECV               0x05
+#define WELCOME_PACKET_SIZE               13
 
 typedef enum iClickerChannelType
 {
     CHANNEL_SEND = 0, //act as a clicker
     CHANNEL_RECV = 1, // act as base station
+    CHANNEL_RECV_WELCOME = 2 // act as base station sending a welcome message
 } iClickerChannelType_t;
 
 /*


### PR DESCRIPTION
@wizard97 Lemme know if I used the `_RECV`/`_SEND` convention right here, I had to expand it out since other packets will also have varying lengths.

@charlescao460 Would appreciate you testing this with a base station, made a change to the way the radio module is used so we don't have to hardcode payload lengths. Also, you can try out the undocumented(?) question modes.